### PR TITLE
Add categories, shuffle, and uppercase styling to word search

### DIFF
--- a/src/wordsearch.js
+++ b/src/wordsearch.js
@@ -70,6 +70,7 @@ function startGame() {
       const wEl = document.createElement('div');
       wEl.textContent = upperWord;
       wEl.id = `word-${upperWord}`;
+      wEl.className = 'word';
       section.appendChild(wEl);
     });
     wordListEl.appendChild(section);

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,10 @@ body {
   font-size: 0.8rem;
 }
 
+.word-list .word {
+  text-transform: uppercase;
+}
+
 .word-list .found {
   text-decoration: line-through;
   text-decoration-color: red;


### PR DESCRIPTION
## Summary
- Organize word list into themed categories and rebuild the board whenever the game starts or shuffle is pressed
- Render letters in uppercase and strike through found words in red
- Convert words to uppercase before grid placement and ensure word list entries are styled consistently

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a241aa5820833288de4f2c9f7f1393