### PR TITLE
Add category-based levels and enhanced styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,10 @@
 </head>
 <body>
   <h1>Word Search Game</h1>
-  <button id="shuffle">Shuffle</button>
+  <div class="controls">
+    <select id="category"></select>
+    <button id="start">Start</button>
+  </div>
   <div id="game" class="game-container"></div>
   <script type="module" src="src/wordsearch.js"></script>
 </body>

--- a/src/grid.js
+++ b/src/grid.js
@@ -2,11 +2,7 @@ export const directions = [
   { dr: 0, dc: 1 },
   { dr: 0, dc: -1 },
   { dr: 1, dc: 0 },
-  { dr: -1, dc: 0 },
-  { dr: 1, dc: 1 },
-  { dr: -1, dc: -1 },
-  { dr: -1, dc: 1 },
-  { dr: 1, dc: -1 }
+  { dr: -1, dc: 0 }
 ];
 
 export function generateGrid(words, gridSize = 12) {

--- a/src/wordsearch.js
+++ b/src/wordsearch.js
@@ -1,19 +1,16 @@
 import { generateGrid } from './grid.js';
 
 const categories = {
-  Fruits: ['BANANA', 'MANGO'],
-  Places: ['LAGOS'],
-  Economy: ['NAIRA', 'TRADE', 'MONEY'],
-  Animals: ['ZEBRA'],
-  Technology: ['PYTHON', 'REACT', 'CODED'],
-  Arts: ['MUSIC', 'DANCE'],
-  Education: ['BOOKS'],
-  Virtues: ['HOPE', 'GIANT']
+  Fruits: ['BANANA', 'MANGO', 'ORANGE', 'PAWPAW', 'GUAVA'],
+  Animals: ['ZEBRA', 'LION', 'GOAT', 'SNAKE', 'ELEPHANT'],
+  Technology: ['PYTHON', 'REACT', 'CODE'],
+  'Nigerian States': ['LAGOS', 'KANO', 'ENUGU', 'ABIA', 'BENUE', 'DELTA', 'KWARA', 'ONDO', 'OSUN', 'KATSINA']
 };
 
 const gridSize = 12;
 const gameContainer = document.getElementById('game');
-const shuffleBtn = document.getElementById('shuffle');
+const categorySelect = document.getElementById('category');
+const startBtn = document.getElementById('start');
 
 let gridEl;
 let wordListEl;
@@ -30,14 +27,25 @@ function shuffle(arr) {
   }
 }
 
+function populateCategories() {
+  Object.keys(categories).forEach((cat) => {
+    const opt = document.createElement('option');
+    opt.value = cat;
+    opt.textContent = cat;
+    categorySelect.appendChild(opt);
+  });
+  categorySelect.value = Object.keys(categories)[0];
+}
+
 function startGame() {
+  const category = categorySelect.value || Object.keys(categories)[0];
   gameContainer.innerHTML = '';
   foundWords = new Set();
   isMouseDown = false;
   startCell = null;
   currentPath = [];
 
-  words = Object.values(categories).flat().map((w) => w.toUpperCase());
+  words = categories[category].map((w) => w.toUpperCase());
   shuffle(words);
 
   const grid = generateGrid(words, gridSize);
@@ -59,22 +67,13 @@ function startGame() {
     });
   });
 
-  for (const [category, list] of Object.entries(categories)) {
-    const section = document.createElement('div');
-    const title = document.createElement('div');
-    title.textContent = category;
-    title.className = 'category-title';
-    section.appendChild(title);
-    list.forEach((word) => {
-      const upperWord = word.toUpperCase();
-      const wEl = document.createElement('div');
-      wEl.textContent = upperWord;
-      wEl.id = `word-${upperWord}`;
-      wEl.className = 'word';
-      section.appendChild(wEl);
-    });
-    wordListEl.appendChild(section);
-  }
+  words.forEach((word) => {
+    const wEl = document.createElement('div');
+    wEl.textContent = word;
+    wEl.id = `word-${word}`;
+    wEl.className = 'word';
+    wordListEl.appendChild(wEl);
+  });
 
   gameContainer.appendChild(gridEl);
   gameContainer.appendChild(wordListEl);
@@ -102,7 +101,7 @@ function getPath(start, end) {
   const stepR = dr === 0 ? 0 : dr / Math.abs(dr);
   const stepC = dc === 0 ? 0 : dc / Math.abs(dc);
 
-  if (dr !== 0 && dc !== 0 && Math.abs(dr) !== Math.abs(dc)) return null;
+  if (dr !== 0 && dc !== 0) return null;
 
   const length = Math.max(Math.abs(dr), Math.abs(dc)) + 1;
   const path = [];
@@ -157,7 +156,9 @@ function handleMouseUp() {
 }
 
 document.addEventListener('mouseup', handleMouseUp);
-shuffleBtn.addEventListener('click', startGame);
+startBtn.addEventListener('click', startGame);
+categorySelect.addEventListener('change', startGame);
 
+populateCategories();
 startGame();
 

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,31 @@
 body {
-  font-family: sans-serif;
+  font-family: 'Arial', sans-serif;
   padding: 1rem;
+  background: linear-gradient(135deg, #f0f4ff, #d9e4ff);
+  color: #333;
+  text-align: center;
+}
+
+.controls {
+  margin-bottom: 1rem;
+}
+
+select,
+button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  margin: 0 0.25rem;
+  background: #4a90e2;
+  color: #fff;
+  cursor: pointer;
 }
 
 .game-container {
   display: flex;
   gap: 1rem;
   align-items: flex-start;
+  justify-content: center;
 }
 
 .grid {
@@ -14,6 +33,9 @@ body {
   grid-template-columns: repeat(var(--grid-size), 30px);
   grid-auto-rows: 30px;
   gap: 2px;
+  background: #fff;
+  border: 2px solid #4a90e2;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 .cell {
@@ -26,17 +48,19 @@ body {
   font-weight: bold;
   user-select: none;
   text-transform: uppercase;
+  transition: background 0.2s;
+  border-radius: 4px;
 }
 
 .cell.selected {
-  background: #ffe58f;
+  background: #ffd54f;
 }
 
 .cell.found {
-  background: #a0e7a0;
-  color: red;
+  background: #4caf50;
+  color: #fff;
   text-decoration: line-through;
-  text-decoration-color: red;
+  text-decoration-color: #fff;
 }
 
 .word-list {
@@ -44,6 +68,10 @@ body {
   flex-direction: column;
   gap: 8px;
   font-size: 0.8rem;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 .word-list .word {

--- a/test/grid.test.js
+++ b/test/grid.test.js
@@ -10,10 +10,10 @@ const gridSize = 12;
 const grid = generateGrid(words, gridSize);
 
 const directions = [
-  { dr: 0, dc: 1 }, { dr: 0, dc: -1 },
-  { dr: 1, dc: 0 }, { dr: -1, dc: 0 },
-  { dr: 1, dc: 1 }, { dr: -1, dc: -1 },
-  { dr: -1, dc: 1 }, { dr: 1, dc: -1 }
+  { dr: 0, dc: 1 },
+  { dr: 0, dc: -1 },
+  { dr: 1, dc: 0 },
+  { dr: -1, dc: 0 }
 ];
 
 function existsWord(word) {


### PR DESCRIPTION
## Summary
- Allow players to choose a category as the play level with a dropdown and start button
- Shuffle words per category and include a Nigerian States category
- Remove diagonal word placement and selection
- Polish visuals with gradients, styled controls, and improved grid colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a24509ea7c8332b938d75bb07b2b4a